### PR TITLE
bugfix_pr24

### DIFF
--- a/scripts/vote.coffee
+++ b/scripts/vote.coffee
@@ -44,7 +44,7 @@ module.exports = (robot) ->
     changeScore(name, -source[name])
     return "success! 10pt消費します"
 
-  robot.hear /^@*(.+?):*\+\+$/i, (msg) ->
+  robot.hear /^@*(.+?)(: )*\+\+$/i, (msg) ->
     name = msg.match[1]
     result_msg = addScore(name, msg.message.user.name)
     msg.send result_msg

--- a/test/vote_test.coffee
+++ b/test/vote_test.coffee
@@ -18,11 +18,11 @@ describe 'vote', ->
     , done
     adapter.receive(new TextMessage(user, 'name++'))
 
-  it 'responds "@name:++"', (done) ->
+  it 'responds "@name: ++"', (done) ->
     adapter.on 'send', (envelope, strings) ->
       expect(strings[0]).to.have.string('name: 1')
     , done
-    adapter.receive(new TextMessage(user, '@name:++'))
+    adapter.receive(new TextMessage(user, '@name: ++'))
 
   it 'deny self vote', (done) ->
     adapter.on 'send', (envelope, strings) ->


### PR DESCRIPTION
slackのユーザ名補完を使用した際に
コロンの後のスペースに対応
